### PR TITLE
Added timestamp to Timeline events and ensured it's sorted

### DIFF
--- a/src/module.mjs
+++ b/src/module.mjs
@@ -104,7 +104,9 @@ export class WebRTCStats extends EventEmitter {
       return this._timeline.filter((event) => event.tag === tag)
     }
 
-    return this._timeline
+    return this._timeline.sort(
+      (ev1, ev2) => ev1.timestamp.getTime() - ev2.timestamp.getTime()
+    );
   }
 
   wrapGetUserMedia (options = {}) {
@@ -865,6 +867,7 @@ export class WebRTCStats extends EventEmitter {
 
   addToTimeline (event) {
     let ev = {
+      timestamp: new Date(),
       ...event
     }
     this._timeline.push(ev)


### PR DESCRIPTION
**Motivation:**

We're interested in having the timestamp in the events timeline for logging/debugging purposes on our project;
I added a timestamp property and later use it to ensure the correct order of the timeline when reading it (I had some cases where the events seemed to have been in the wrong order, namely around getUserMedia events)