### PR TITLE
Drop interval id after clearing

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -187,6 +187,8 @@ export class WebRTCStats extends EventEmitter {
       // if we ran out of peers to monitor
       if (!Object.keys(this.peersToMonitor).length) {
         window.clearInterval(this.monitoringSetInterval)
+
+        this.monitoringSetInterval = 0
       }
 
       for (const key in this.peersToMonitor) {


### PR DESCRIPTION
Hi!

I found that one instance of `WebRTCStats` can't handle new added peer after previous peer was closed.
This PR fixes that.