### PR TITLE
Add ability to clean timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Stop listening to all event listeners and reset the state of the instance. Usefu
 
 A new instance of `WebRTCStats` should be used if you would like to start monitoring again.
 
+#### `.clearTimeline()`
+
+Clears the internal timeline array.
+
 ### Events
 The module uses `EventEmitter` to emit events. You can listen to them using `.on()`
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,13 @@ export class WebRTCStats extends EventEmitter {
   }
 
   /**
+   * Clears the timeline of events
+   */
+  public clearTimeline (): void {
+    this.timeline = []
+  }
+
+  /**
    * Used to remove all event listeners and reset the state of the lib
    */
   public destroy () {
@@ -340,6 +347,9 @@ export class WebRTCStats extends EventEmitter {
       // put back the original
       navigator.mediaDevices.getUserMedia = origGetUserMedia
     }
+
+    // clear the timeline
+    this.clearTimeline()
   }
 
   /**


### PR DESCRIPTION
Fixes #19

Add ability to clean timeline in WebRTCStats.

- Add `clearTimeline` method to the `WebRTCStats` class in `src/index.ts` to clear the timeline of events.
- Update the `destroy` method in `src/index.ts` to call the `clearTimeline` method, ensuring the timeline is cleared at the end of the session.
- Update `README.md` to include documentation for the new `clearTimeline` method in the API section.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peermetrics/webrtc-stats/issues/19?shareId=07d031fa-e111-4f6b-9393-9cca1e9e5651).