### PR TITLE
Feat/v5.9.0 display media wrap

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 Andrei Onel <andrei@peermetrics.io>
+Copyright (c) 2025-present Alberto Gonzalez <alberto@webrtc.ventures> (WebRTC.ventures)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/example/index.html
+++ b/example/index.html
@@ -73,6 +73,14 @@
       Charts use parsed <strong>stats</strong> when the browser exposes them (names vary by engine).
       Core: bitrate, jitter, RTT, loss. Advanced: video drops/freezes, NACK/retransmits, encoder quality
       limitation (Chrome), audio concealment samples.
+      Use <strong>New session</strong> to tear down <code>WebRTCStats</code> and create a fresh instance
+      (same as users who end a call and start another without refreshing the page).
+      Use <strong>Share screen</strong> to exercise <code>wrapGetDisplayMedia</code>: the library
+      emits <code>getDisplayMedia</code> timeline events (request/stream/error) just like it does
+      for <code>getUserMedia</code>. The screen replaces <em>only</em> peer&nbsp;1's outbound video
+      (via <code>replaceTrack</code>), so expect <strong>peer&nbsp;2's inbound bitrate</strong> to shift
+      to screen-share levels while <strong>peer&nbsp;1's inbound</strong> stays on camera (peer&nbsp;2
+      is still sending its camera track unchanged) — that asymmetry is the intended behavior, not a bug.
     </p>
 
     <div class="row">
@@ -90,6 +98,9 @@
       <button type="button" id="startButton">Start camera</button>
       <button type="button" id="callButton" disabled>Connect (offer/answer)</button>
       <button type="button" id="hangupButton" disabled>Hang up</button>
+      <button type="button" id="newSessionButton" title="Destroy WebRTCStats and create a new one (simulates a new visit without refresh)">New session (no refresh)</button>
+      <button type="button" id="shareScreenButton" title="Replaces peer 1's outbound video with the screen — only peer 2's inbound changes (peer 1's inbound stays on camera from peer 2)">Share screen (peer 1 → peer 2)</button>
+      <button type="button" id="stopShareButton" disabled title="Stops the screen share and restores the camera on peer 1's sender">Stop share</button>
     </div>
 
     <h2 style="font-size:0.9rem">Latest parsed stats (peer 1 &amp; 2)</h2>
@@ -101,6 +112,10 @@
       <div class="chart-box">
         <h3>Receive bitrate (inbound audio + video, kb/s)</h3>
         <canvas id="chartBitrate" height="160"></canvas>
+      </div>
+      <div class="chart-box">
+        <h3>Send bitrate (outbound audio + video, kb/s)</h3>
+        <canvas id="chartTxBitrate" height="160"></canvas>
       </div>
       <div class="chart-box">
         <h3>Jitter — inbound (ms)</h3>
@@ -182,17 +197,21 @@
           if (!d) return null
           let rxKbps = 0
           let hasBr = false
-          function addInboundBitrate (list) {
+          let txKbps = 0
+          let hasTxBr = false
+          function addBitrate (list, inbound) {
             if (!list) return
             list.forEach(function (r) {
               if (r.bitrate != null && !Number.isNaN(r.bitrate)) {
-                rxKbps += r.bitrate / 1000
-                hasBr = true
+                if (inbound) { rxKbps += r.bitrate / 1000; hasBr = true }
+                else { txKbps += r.bitrate / 1000; hasTxBr = true }
               }
             })
           }
-          addInboundBitrate(d.audio && d.audio.inbound)
-          addInboundBitrate(d.video && d.video.inbound)
+          addBitrate(d.audio && d.audio.inbound, true)
+          addBitrate(d.video && d.video.inbound, true)
+          addBitrate(d.audio && d.audio.outbound, false)
+          addBitrate(d.video && d.video.outbound, false)
 
           const inboundRows = []
             .concat(d.audio && d.audio.inbound ? d.audio.inbound : [])
@@ -239,6 +258,7 @@
 
           return {
             rxKbps: hasBr ? rxKbps : null,
+            txKbps: hasTxBr ? txKbps : null,
             jitterMs: jitterMs,
             rttMs: rttMs,
             pktsLost: inboundRows.length ? pktsLost : null,
@@ -253,6 +273,7 @@
 
         const METRIC_DEFAULTS = {
           rxKbps: null,
+          txKbps: null,
           jitterMs: null,
           rttMs: null,
           pktsLost: null,
@@ -268,6 +289,7 @@
         const charts = {}
         const chartIds = [
           { id: 'chartBitrate', key: 'rxKbps', yMax: null },
+          { id: 'chartTxBitrate', key: 'txKbps', yMax: null },
           { id: 'chartJitter', key: 'jitterMs', yMax: null },
           { id: 'chartRtt', key: 'rttMs', yMax: null },
           { id: 'chartLost', key: 'pktsLost', yMax: null },
@@ -281,7 +303,7 @@
 
         function chartOpts (key, yMax) {
           var yZero = [
-            'pktsLost', 'rxKbps', 'vidFramesDropped', 'vidFreezeSec', 'nackIn', 'retransIn', 'audioConcealed'
+            'pktsLost', 'rxKbps', 'txKbps', 'vidFramesDropped', 'vidFreezeSec', 'nackIn', 'retransIn', 'audioConcealed'
           ].indexOf(key) >= 0
           var y = { beginAtZero: yZero, ticks: { font: { size: 9 } } }
           if (yMax != null) {
@@ -355,16 +377,6 @@
           lastByPeer['2'] = null
         }
 
-        window.stats = new WebRTCStats({
-          getStatsInterval: 2000,
-          rawStats: false,
-          statsObject: false,
-          filteredStats: false,
-          wrapGetUserMedia: true,
-          debug: false,
-          remote: true
-        })
-
         const logEl = document.getElementById('logOut')
         const maxLogLines = 12
         function logLine (msg) {
@@ -374,25 +386,9 @@
           logEl.textContent = lines.slice(-maxLogLines).join('\n')
         }
 
-        window.stats.on('timeline', function (ev) {
-          if (ev.tag === 'stats') return
-          if (ev.tag === 'getUserMedia') {
-            console.log('[webrtc-stats demo] getUserMedia (full timeline event)', ev)
-            if (ev.data && ev.data.constraints) {
-              logLine('getUserMedia · request ' + JSON.stringify(ev.data.constraints))
-              return
-            }
-            if (ev.data && ev.data.stream) {
-              logLine('getUserMedia · stream acquired (tracks: ' + ev.data.stream.getTracks().map(function (t) { return t.kind }).join(', ') + ')')
-              return
-            }
-            logLine('getUserMedia · ' + (ev.event || 'event'))
-            return
-          }
-          logLine(ev.tag + ' · ' + (ev.event || '') + (ev.data != null && typeof ev.data === 'string' ? ' · ' + ev.data : ''))
-        })
-
         const statsOut = document.getElementById('statsOut')
+        let statsSessionId = 0
+
         function summarizeStatsData (d) {
           if (!d) return '(empty)'
           const parts = []
@@ -428,20 +424,76 @@
         }
 
         const lastStatsByPeer = {}
-        window.stats.on('stats', function (ev) {
-          console.log('[webrtc-stats demo] stats', 'peer=' + ev.peerId, ev.timeTaken + ' ms', ev.data)
-          const chartM = extractChartMetrics(ev.data)
-          if (chartM) lastByPeer[ev.peerId] = chartM
-          pushSample()
 
-          lastStatsByPeer[ev.peerId] =
-            'getStats ' + ev.timeTaken + ' ms\n' + summarizeStatsData(ev.data)
-          statsOut.textContent =
-            '=== peer 1 ===\n' + (lastStatsByPeer['1'] || '…') +
-            '\n\n=== peer 2 ===\n' + (lastStatsByPeer['2'] || '…')
-        })
+        function wireStatsInstance (stats) {
+          stats.on('timeline', function (ev) {
+            if (ev.tag === 'stats') return
+            if (ev.tag === 'getUserMedia' || ev.tag === 'getDisplayMedia') {
+              console.log('[webrtc-stats demo] ' + ev.tag + ' (full timeline event)', ev)
+              if (ev.data && ev.data.constraints) {
+                logLine(ev.tag + ' · request ' + JSON.stringify(ev.data.constraints))
+                return
+              }
+              if (ev.data && ev.data.stream) {
+                logLine(ev.tag + ' · stream acquired (tracks: ' + ev.data.stream.getTracks().map(function (t) { return t.kind }).join(', ') + ')')
+                return
+              }
+              if (ev.data && ev.data.error) {
+                logLine(ev.tag + ' · error ' + ev.data.error.name + ': ' + ev.data.error.message)
+                return
+              }
+              logLine(ev.tag + ' · ' + (ev.event || 'event'))
+              return
+            }
+            logLine(ev.tag + ' · ' + (ev.event || '') + (ev.data != null && typeof ev.data === 'string' ? ' · ' + ev.data : ''))
+          })
+
+          stats.on('stats', function (ev) {
+            console.log('[webrtc-stats demo] stats', 'peer=' + ev.peerId, ev.timeTaken + ' ms', ev.data)
+            const chartM = extractChartMetrics(ev.data)
+            if (chartM) lastByPeer[ev.peerId] = chartM
+            pushSample()
+
+            lastStatsByPeer[ev.peerId] =
+              'getStats ' + ev.timeTaken + ' ms\n' + summarizeStatsData(ev.data)
+            statsOut.textContent =
+              '=== peer 1 ===\n' + (lastStatsByPeer['1'] || '…') +
+              '\n\n=== peer 2 ===\n' + (lastStatsByPeer['2'] || '…')
+          })
+        }
+
+        /**
+         * Creates a new WebRTCStats (or replaces after destroy). Safe to call multiple times per page
+         * to simulate customers who reinitialize Peermetrics between calls without refresh.
+         */
+        window.createWebRTCStatsSession = function () {
+          if (window.stats) {
+            try {
+              window.stats.destroy()
+            } catch (e) {
+              console.warn('[webrtc-stats demo] destroy()', e)
+            }
+          }
+          delete lastStatsByPeer['1']
+          delete lastStatsByPeer['2']
+          statsSessionId += 1
+          window.stats = new WebRTCStats({
+            getStatsInterval: 2000,
+            rawStats: false,
+            statsObject: false,
+            filteredStats: false,
+            wrapGetUserMedia: true,
+            wrapGetDisplayMedia: true,
+            debug: false,
+            remote: true
+          })
+          wireStatsInstance(window.stats)
+          logLine('WebRTCStats session #' + statsSessionId + ' started (wrapGetUserMedia=true, wrapGetDisplayMedia=true)')
+          return window.stats
+        }
 
         initCharts()
+        window.createWebRTCStatsSession()
         window.demoLogLine = logLine
       })()
     </script>
@@ -452,6 +504,10 @@
       const startButton = document.getElementById('startButton')
       const callButton = document.getElementById('callButton')
       const hangupButton = document.getElementById('hangupButton')
+      const newSessionButton = document.getElementById('newSessionButton')
+      const shareScreenButton = document.getElementById('shareScreenButton')
+      const stopShareButton = document.getElementById('stopShareButton')
+      let screenStream
       const localVideo = document.getElementById('localVideo')
       const remoteVideo = document.getElementById('remoteVideo')
 
@@ -499,8 +555,8 @@
         pc2.addEventListener('icecandidate', function (e) { onIceCandidate(pc2, e) })
         pc2.addEventListener('track', gotRemoteStream)
 
-        stats.addConnection({ pc: pc1, peerId: '1' })
-        stats.addConnection({ pc: pc2, peerId: '2' })
+        window.stats.addConnection({ pc: pc1, peerId: '1' })
+        window.stats.addConnection({ pc: pc2, peerId: '2' })
 
         mediaStream.getTracks().forEach(function (track) {
           pc1.addTrack(track, mediaStream)
@@ -538,8 +594,15 @@
 
       function hangup () {
         if (window.demoLogLine) window.demoLogLine('hangup · stopping tracks and closing peer connections')
+        if (screenStream) {
+          screenStream.getTracks().forEach(function (t) { t.stop() })
+          screenStream = null
+        }
+        cameraVideoTrack = null
+        stopShareButton.disabled = true
+        shareScreenButton.disabled = false
         if (window.stats) {
-          stats.removeAllPeers()
+          window.stats.removeAllPeers()
         }
         if (pc1) {
           pc1.getSenders().forEach(function (s) { if (s.track) s.track.stop() })
@@ -563,9 +626,96 @@
         startButton.disabled = false
       }
 
+      function newSessionWithoutRefresh () {
+        if (window.demoLogLine) {
+          window.demoLogLine('New session · hang up + destroy/recreate WebRTCStats (no page reload)')
+        }
+        hangup()
+        stopShare()
+        if (typeof window.resetStatsCharts === 'function') window.resetStatsCharts()
+        if (typeof window.createWebRTCStatsSession === 'function') window.createWebRTCStatsSession()
+        document.getElementById('statsOut').textContent =
+          'New WebRTCStats session — use Start camera when ready.'
+      }
+
+      /** The camera video track we temporarily replaced on the sender during a screen share. */
+      let cameraVideoTrack = null
+
+      function findVideoSender (pc) {
+        if (!pc) return null
+        const senders = pc.getSenders()
+        for (let i = 0; i < senders.length; i++) {
+          if (senders[i].track && senders[i].track.kind === 'video') return senders[i]
+        }
+        return null
+      }
+
+      async function shareScreen () {
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+          if (window.demoLogLine) window.demoLogLine('getDisplayMedia not supported in this browser')
+          return
+        }
+        if (screenStream) return
+        shareScreenButton.disabled = true
+        try {
+          screenStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false })
+          const screenTrack = screenStream.getVideoTracks()[0]
+          if (window.demoLogLine) {
+            window.demoLogLine('screen share started (tracks: ' + screenStream.getTracks().map(function (t) { return t.kind }).join(', ') + ')')
+          }
+
+          // Push the screen track into the active call so peer 2 actually sees it.
+          // We replaceTrack on pc1's existing video sender — same SSRC, no renegotiation.
+          const videoSender = findVideoSender(pc1)
+          if (videoSender && screenTrack) {
+            cameraVideoTrack = videoSender.track
+            await videoSender.replaceTrack(screenTrack)
+            if (window.demoLogLine) window.demoLogLine('replaceTrack · camera → screen (peer 1 sender)')
+            // Preview the shared screen locally so the demo looks right.
+            localVideo.srcObject = screenStream
+          } else if (window.demoLogLine) {
+            window.demoLogLine('no active video sender · connect the call first to see it on peer 2')
+          }
+
+          screenTrack.addEventListener('ended', function () {
+            if (window.demoLogLine) window.demoLogLine('screen share ended by user (native stop button)')
+            stopShare()
+          })
+          stopShareButton.disabled = false
+        } catch (e) {
+          screenStream = null
+          if (window.demoLogLine) window.demoLogLine('getDisplayMedia failed: ' + e.message)
+          shareScreenButton.disabled = false
+        }
+      }
+
+      async function stopShare () {
+        if (!screenStream) return
+        const videoSender = findVideoSender(pc1)
+        if (videoSender && cameraVideoTrack && cameraVideoTrack.readyState === 'live') {
+          try {
+            await videoSender.replaceTrack(cameraVideoTrack)
+            if (window.demoLogLine) window.demoLogLine('replaceTrack · screen → camera (peer 1 sender)')
+          } catch (e) {
+            if (window.demoLogLine) window.demoLogLine('replaceTrack back failed: ' + e.message)
+          }
+        }
+        screenStream.getTracks().forEach(function (t) { t.stop() })
+        screenStream = null
+        cameraVideoTrack = null
+        // Restore local preview to the camera stream if we still have it.
+        if (mediaStream) localVideo.srcObject = mediaStream
+        stopShareButton.disabled = true
+        shareScreenButton.disabled = false
+        if (window.demoLogLine) window.demoLogLine('screen share stopped')
+      }
+
       startButton.addEventListener('click', start)
       callButton.addEventListener('click', call)
       hangupButton.addEventListener('click', hangup)
+      newSessionButton.addEventListener('click', newSessionWithoutRefresh)
+      shareScreenButton.addEventListener('click', shareScreen)
+      stopShareButton.addEventListener('click', stopShare)
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peermetrics/webrtc-stats",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Library that helps collect and parse webrtc stats.",
   "main": "dist/index.js",
   "repository": "https://github.com/peermetrics/webrtc-stats",
@@ -18,7 +18,7 @@
     "serve": "http-server example",
     "watch": "rollup -c rollup.config.mjs -w",
     "prepublishOnly": "npm run build",
-    "test": "tsx --test test/basic.test.ts"
+    "test": "tsx --test test/basic.test.ts test/getUserMedia-wrap.test.ts test/getDisplayMedia-wrap.test.ts"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Library that helps collect and parse webrtc stats.",
   "main": "dist/index.js",
   "repository": "https://github.com/peermetrics/webrtc-stats",
-  "author": "Andrei Onel <andrei@peermetrics.io>",
+  "author": "Alberto Gonzalez <alberto@webrtc.ventures> (https://webrtc.ventures)",
+  "contributors": [
+    "Andrei Onel <andrei@peermetrics.io>"
+  ],
   "license": "MIT",
   "keywords": [
     "webrtc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,41 @@ import {parseStats, map2obj} from './utils'
 // used to keep track of events listeners. useful when we want to remove them
 let eventListeners = {}
 
-// used to save the original getUsermedia native method
-let origGetUserMedia
-
 // tracks that have been obtained from calling getUsermedia
 let localTracks = []
+
+/**
+ * Shared state for wrapping `navigator.mediaDevices.getUserMedia`.
+ *
+ * We only ever replace `getUserMedia` once per page. If another WebRTCStats is created
+ * later, it just subscribes to the wrapper that's already there.
+ *
+ * Why: in the past, each new WebRTCStats would wrap `getUserMedia` again and save its
+ * own "original" pointer. A second instance would save the first wrapper as the
+ * "original", and the first wrapper would end up calling itself — infinite recursion
+ * ("Maximum call stack size exceeded"). This happened in apps that recreate
+ * WebRTCStats per call/session without reloading the page.
+ */
+type GetUserMediaFn = typeof navigator.mediaDevices.getUserMedia
+type GumSubscriber = (info: { constraints?: MediaStreamConstraints, stream?: MediaStream, error?: Error }) => void
+
+const GUM_WRAP_MARKER = '__webrtcStatsGumWrapped__'
+let gumInstalledWrapper: GetUserMediaFn | null = null
+let gumPreviousImpl: GetUserMediaFn | null = null
+const gumSubscribers: Set<GumSubscriber> = new Set()
+
+/**
+ * Shared state for wrapping `navigator.mediaDevices.getDisplayMedia` (screen share).
+ * Same contract as the getUserMedia wrap: at most one wrapper per page, instances
+ * subscribe, and native is restored only when the last subscriber is destroyed.
+ */
+type GetDisplayMediaFn = (constraints?: any) => Promise<MediaStream>
+type GdmSubscriber = (info: { constraints?: any, stream?: MediaStream, error?: Error }) => void
+
+const GDM_WRAP_MARKER = '__webrtcStatsGdmWrapped__'
+let gdmInstalledWrapper: GetDisplayMediaFn | null = null
+let gdmPreviousImpl: GetDisplayMediaFn | null = null
+const gdmSubscribers: Set<GdmSubscriber> = new Set()
 
 export class WebRTCStats extends EventEmitter {
   private readonly isEdge: boolean
@@ -35,6 +65,11 @@ export class WebRTCStats extends EventEmitter {
   private readonly statsObject: boolean
   private readonly filteredStats: boolean
   private readonly shouldWrapGetUserMedia: boolean
+  private readonly shouldWrapGetDisplayMedia: boolean
+  /** The `getUserMedia` subscriber this instance registered (if `wrapGetUserMedia: true`). */
+  private gumSubscriber: GumSubscriber | null = null
+  /** The `getDisplayMedia` subscriber this instance registered (if `wrapGetDisplayMedia: true`). */
+  private gdmSubscriber: GdmSubscriber | null = null
   private debug: any
   private readonly remote: boolean = true
   private peersToMonitor: MonitoredPeersObject = {}
@@ -82,8 +117,8 @@ export class WebRTCStats extends EventEmitter {
     this.statsObject = !!options.statsObject
     this.filteredStats = !!options.filteredStats
 
-    // getUserMedia options
     this.shouldWrapGetUserMedia = !!options.wrapGetUserMedia
+    this.shouldWrapGetDisplayMedia = !!options.wrapGetDisplayMedia
 
     if (typeof options.remote === 'boolean') {
       this.remote = options.remote
@@ -93,9 +128,12 @@ export class WebRTCStats extends EventEmitter {
     this.debug = !!options.debug
     this.logLevel = options.logLevel || "none"
 
-    // add event listeners for getUserMedia
     if (this.shouldWrapGetUserMedia) {
       this.wrapGetUserMedia()
+    }
+
+    if (this.shouldWrapGetDisplayMedia) {
+      this.wrapGetDisplayMedia()
     }
   }
 
@@ -342,10 +380,12 @@ export class WebRTCStats extends EventEmitter {
 
     localTracks = []
 
-    // if we wrapped gUM initially
-    if (this.shouldWrapGetUserMedia && origGetUserMedia) {
-      // put back the original
-      navigator.mediaDevices.getUserMedia = origGetUserMedia
+    if (this.gumSubscriber) {
+      this.unwrapGetUserMedia()
+    }
+
+    if (this.gdmSubscriber) {
+      this.unwrapGetDisplayMedia()
     }
 
     // clear the timeline
@@ -562,27 +602,78 @@ export class WebRTCStats extends EventEmitter {
       return
     }
 
-    this.logger.info('Wrapping getUsermedia functions.')
+    // Register this instance's subscriber — it will be called for every gUM invocation
+    // while this instance is alive.
+    const subscriber: GumSubscriber = this.parseGetUserMedia.bind(this)
+    this.gumSubscriber = subscriber
+    gumSubscribers.add(subscriber)
 
-    origGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices)
+    // If another WebRTCStats already wrapped gUM on this page, just subscribe; do not wrap again.
+    // This keeps the wrapper chain at depth 1 no matter how many instances coexist.
+    const current = navigator.mediaDevices.getUserMedia as GetUserMediaFn & { [GUM_WRAP_MARKER]?: boolean }
+    if (current && current[GUM_WRAP_MARKER]) {
+      this.logger.info('getUserMedia already wrapped by WebRTCStats; subscribing this instance.')
+      return
+    }
 
-    const getUserMediaCallback = this.parseGetUserMedia.bind(this)
-    const gum = function () {
-      // the first call will be with the constraints
-      getUserMediaCallback({constraints: arguments[0]})
+    this.logger.info('Wrapping getUserMedia.')
 
-      return origGetUserMedia.apply(navigator.mediaDevices, arguments)
+    // Remember whatever was installed before us (native or another library's wrapper) so we
+    // can restore it when the last subscriber is destroyed.
+    gumPreviousImpl = navigator.mediaDevices.getUserMedia
+
+    const previous = gumPreviousImpl
+    const wrapped = function (this: MediaDevices, constraints: MediaStreamConstraints) {
+      // Fan out the "request" event before delegating so consumers see constraints immediately.
+      gumSubscribers.forEach((sub) => {
+        try { sub({ constraints }) } catch (_e) { /* isolate subscriber errors */ }
+      })
+
+      return previous.apply(navigator.mediaDevices, [constraints])
         .then((stream) => {
-          getUserMediaCallback({stream: stream})
+          gumSubscribers.forEach((sub) => {
+            try { sub({ stream }) } catch (_e) { /* isolate subscriber errors */ }
+          })
           return stream
         }, (err) => {
-          getUserMediaCallback({error: err})
+          gumSubscribers.forEach((sub) => {
+            try { sub({ error: err }) } catch (_e) { /* isolate subscriber errors */ }
+          })
           return Promise.reject(err)
         })
     }
 
-    // replace the native method
-    navigator.mediaDevices.getUserMedia = gum.bind(navigator.mediaDevices)
+    const bound = wrapped.bind(navigator.mediaDevices) as GetUserMediaFn & { [GUM_WRAP_MARKER]?: boolean }
+    bound[GUM_WRAP_MARKER] = true
+    gumInstalledWrapper = bound
+    navigator.mediaDevices.getUserMedia = bound
+  }
+
+  private unwrapGetUserMedia (): void {
+    if (!this.gumSubscriber) return
+
+    gumSubscribers.delete(this.gumSubscriber)
+    this.gumSubscriber = null
+
+    // Only restore when the last subscriber has been removed.
+    if (gumSubscribers.size > 0) return
+    if (!gumInstalledWrapper) return
+    if (!navigator.mediaDevices) return
+
+    if (navigator.mediaDevices.getUserMedia === gumInstalledWrapper) {
+      navigator.mediaDevices.getUserMedia = gumPreviousImpl as GetUserMediaFn
+    } else {
+      // Another library wrapped on top of ours after we installed. Leave the outer wrapper
+      // in place; removing it would break that library. Our subscriber set is empty, so our
+      // wrapper is now a no-op pass-through.
+      this.logger.warn(
+        'getUserMedia was wrapped again after WebRTCStats installed; not restoring native. ' +
+        'The outer wrapper remains; our wrapper now passes through to the previous implementation.'
+      )
+    }
+
+    gumInstalledWrapper = null
+    gumPreviousImpl = null
   }
 
 
@@ -964,26 +1055,95 @@ export class WebRTCStats extends EventEmitter {
     return Date.now()
   }
 
-  // TODO
-  private wrapGetDisplayMedia () {
-    const self = this
-    // @ts-ignore
-    if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
-      // @ts-ignore
-      const origGetDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices)
-      const gdm = function () {
-        self.debug('navigator.mediaDevices.getDisplayMedia', null, arguments[0])
-        return origGetDisplayMedia.apply(navigator.mediaDevices, arguments)
-          .then(function (stream: MediaStream) {
-            // self.debug('navigator.mediaDevices.getDisplayMediaOnSuccess', null, dumpStream(stream))
-            return stream
-          }, function (err: Error) {
-            self.debug('navigator.mediaDevices.getDisplayMediaOnFailure', null, err.name)
-            return Promise.reject(err)
-          })
+  private parseGetDisplayMedia (options: { constraints?: any, stream?: MediaStream, error?: Error }) {
+    try {
+      const obj = {
+        event: 'getDisplayMedia',
+        tag: 'getDisplayMedia',
+        data: {...options}
+      } as TimelineEvent
+
+      if (options.stream) {
+        obj.data.details = this.parseStream(options.stream)
+
+        // attach track listeners for screen-share tracks (mute/unmute/end fire like for gUM)
+        options.stream.getTracks().map((track) => {
+          this.addTrackEventListeners(track)
+          localTracks.push(track)
+        })
       }
-      // @ts-ignore
-      navigator.mediaDevices.getDisplayMedia = gdm.bind(navigator.mediaDevices)
+
+      this.emitEvent(obj)
+    } catch (e) {}
+  }
+
+  private wrapGetDisplayMedia (): void {
+    const mediaDevices = navigator.mediaDevices as (MediaDevices & { getDisplayMedia?: GetDisplayMediaFn }) | undefined
+    if (!mediaDevices || typeof mediaDevices.getDisplayMedia !== 'function') {
+      this.logger.warn(`'navigator.mediaDevices.getDisplayMedia' is not available in browser. Will not wrap getDisplayMedia.`)
+      return
     }
+
+    const subscriber: GdmSubscriber = this.parseGetDisplayMedia.bind(this)
+    this.gdmSubscriber = subscriber
+    gdmSubscribers.add(subscriber)
+
+    const current = mediaDevices.getDisplayMedia as GetDisplayMediaFn & { [GDM_WRAP_MARKER]?: boolean }
+    if (current && current[GDM_WRAP_MARKER]) {
+      this.logger.info('getDisplayMedia already wrapped by WebRTCStats; subscribing this instance.')
+      return
+    }
+
+    this.logger.info('Wrapping getDisplayMedia.')
+
+    gdmPreviousImpl = mediaDevices.getDisplayMedia as GetDisplayMediaFn
+    const previous = gdmPreviousImpl
+    const wrapped = function (this: MediaDevices, constraints?: any) {
+      gdmSubscribers.forEach((sub) => {
+        try { sub({ constraints }) } catch (_e) { /* isolate subscriber errors */ }
+      })
+
+      return previous.apply(navigator.mediaDevices, [constraints])
+        .then((stream: MediaStream) => {
+          gdmSubscribers.forEach((sub) => {
+            try { sub({ stream }) } catch (_e) { /* isolate subscriber errors */ }
+          })
+          return stream
+        }, (err: Error) => {
+          gdmSubscribers.forEach((sub) => {
+            try { sub({ error: err }) } catch (_e) { /* isolate subscriber errors */ }
+          })
+          return Promise.reject(err)
+        })
+    }
+
+    const bound = wrapped.bind(navigator.mediaDevices) as GetDisplayMediaFn & { [GDM_WRAP_MARKER]?: boolean }
+    bound[GDM_WRAP_MARKER] = true
+    gdmInstalledWrapper = bound
+    ;(mediaDevices as any).getDisplayMedia = bound
+  }
+
+  private unwrapGetDisplayMedia (): void {
+    if (!this.gdmSubscriber) return
+
+    gdmSubscribers.delete(this.gdmSubscriber)
+    this.gdmSubscriber = null
+
+    if (gdmSubscribers.size > 0) return
+    if (!gdmInstalledWrapper) return
+    const mediaDevices = navigator.mediaDevices as (MediaDevices & { getDisplayMedia?: GetDisplayMediaFn }) | undefined
+    if (!mediaDevices) return
+
+    if (mediaDevices.getDisplayMedia === gdmInstalledWrapper) {
+      ;(mediaDevices as any).getDisplayMedia = gdmPreviousImpl as GetDisplayMediaFn
+    } else {
+      this.logger.warn(
+        'getDisplayMedia was wrapped again after WebRTCStats installed; not restoring native. ' +
+        'The outer wrapper remains; our wrapper now passes through to the previous implementation.'
+      )
+    }
+
+    gdmInstalledWrapper = null
+    gdmPreviousImpl = null
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export interface WebRTCStatsConstructorOptions {
     statsObject: boolean
     filteredStats: boolean
     wrapGetUserMedia: boolean
+    /** If true, also wrap `navigator.mediaDevices.getDisplayMedia` (screen share). */
+    wrapGetDisplayMedia?: boolean
     debug: boolean
     remote: boolean
     logLevel: LogLevel
@@ -19,7 +21,7 @@ export interface WebRTCStatsConstructorOptions {
  */
 export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'debug'
 
-export type TimelineTag = 'getUserMedia' | 'peer' | 'connection' | 'track' | 'datachannel' | 'stats'
+export type TimelineTag = 'getUserMedia' | 'getDisplayMedia' | 'peer' | 'connection' | 'track' | 'datachannel' | 'stats'
 
 export interface TimelineEvent {
     event: string
@@ -61,6 +63,12 @@ export interface GetUserMediaResponse {
     error?: Error
 }
 
+export interface GetDisplayMediaResponse {
+    constraints?: any
+    stream?: MediaStream
+    error?: Error
+}
+
 export interface MonitorPeerOptions {
     peerId: string
     pc: RTCPeerConnection
@@ -98,6 +106,8 @@ export interface RemoveConnectionReturn {
 export interface TrackReport extends RTCStats {
     bitrate?: number | null
     packetRate?: number | null
+    /** Fraction of inbound packets lost between the previous and current sample, in [0, 1]. */
+    packetLossRate?: number | null
 }
 
 interface StatsObjectDetails {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,12 +12,13 @@ function addDerivedRatesForMedia (
   current.inbound.forEach((report) => {
     const prev = previous.inbound.find(r => r.id === report.id)
     report.bitrate = computeBitrate(report, prev, 'bytesReceived')
-    report.packetRate = computeBitrate(report, prev, 'packetsReceived')
+    report.packetRate = computeRate(report, prev, 'packetsReceived')
+    report.packetLossRate = computePacketLossRate(report, prev)
   })
   current.outbound.forEach((report) => {
     const prev = previous.outbound.find(r => r.id === report.id)
     report.bitrate = computeBitrate(report, prev, 'bytesSent')
-    report.packetRate = computeBitrate(report, prev, 'packetsSent')
+    report.packetRate = computeRate(report, prev, 'packetsSent')
   })
 }
 
@@ -53,8 +54,19 @@ function getCandidatePairInfo (candidatePair, stats) {
   return connection
 }
 
-// Takes two stats reports and determines the rate based on two counter readings
-// and the time between them (which is in units of milliseconds).
+/**
+ * Rate per second between two counter readings in two stats reports.
+ *
+ * Returns `null` (never `NaN`) when:
+ *  - `oldReport` is missing (first sample),
+ *  - either counter is missing or non-numeric,
+ *  - the timestamp delta is zero or negative (stale / duplicated samples),
+ *  - the counter regressed (ICE restart, renegotiation, clock skew) — a negative
+ *    rate would be misleading.
+ *
+ * Counters are cast via `Number(...)` so future browsers returning `BigInt`
+ * (spec: unsigned long long) do not throw inside the subtraction.
+ */
 export function computeRate (newReport: TrackReport, oldReport: TrackReport, statName: string): number | null {
   if (!oldReport) return null
   const newVal = newReport[statName]
@@ -64,9 +76,10 @@ export function computeRate (newReport: TrackReport, oldReport: TrackReport, sta
   const o = Number(oldVal)
   if (Number.isNaN(n) || Number.isNaN(o)) return null
   const dt = newReport.timestamp - oldReport.timestamp
-  // Same timestamp (common for some remote-* reports) → avoid 0/0 → NaN
   if (!(dt > 0)) return null
-  return ((n - o) / dt) * 1000
+  const delta = n - o
+  if (delta < 0) return null
+  return (delta / dt) * 1000
 }
 
 // Convert a byte rate to a bit rate.
@@ -74,6 +87,38 @@ export function computeBitrate (newReport: TrackReport, oldReport: TrackReport, 
   const rate = computeRate(newReport, oldReport, statName)
   if (rate == null) return null
   return rate * 8
+}
+
+/**
+ * Fraction of inbound RTP packets lost between samples, clamped to [0, 1].
+ * Returns `null` if we can't compute it safely (no previous sample, missing
+ * counters, regressed counters, or zero denominator).
+ */
+export function computePacketLossRate (newReport: TrackReport, oldReport: TrackReport): number | null {
+  if (!oldReport) return null
+  const lostNow = newReport['packetsLost']
+  const lostPrev = oldReport['packetsLost']
+  const recvNow = newReport['packetsReceived']
+  const recvPrev = oldReport['packetsReceived']
+  if (lostNow == null || lostPrev == null || recvNow == null || recvPrev == null) return null
+
+  const ln = Number(lostNow)
+  const lp = Number(lostPrev)
+  const rn = Number(recvNow)
+  const rp = Number(recvPrev)
+  if ([ln, lp, rn, rp].some(v => Number.isNaN(v))) return null
+
+  const lostDelta = ln - lp
+  const recvDelta = rn - rp
+  // Packets late-arriving can briefly make lost delta negative (spec-allowed); treat as zero.
+  const lost = lostDelta > 0 ? lostDelta : 0
+  if (recvDelta < 0) return null
+  const total = recvDelta + lost
+  if (total <= 0) return null
+  const rate = lost / total
+  if (rate < 0) return 0
+  if (rate > 1) return 1
+  return rate
 }
 
 export function map2obj (stats: any) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseStats, computeRate, map2obj } from '../src/utils.ts'
+import { parseStats, computeRate, map2obj, computePacketLossRate } from '../src/utils.ts'
 
 /** Minimal RTCStatsReport-like map (values + get + forEach for map2obj) */
 function mockStatsMap (reports: Record<string, any>) {
@@ -22,6 +22,41 @@ test('computeRate: null when timestamps identical (no NaN)', () => {
   const prev = { timestamp: 1000, bytesReceived: 100 }
   const next = { timestamp: 1000, bytesReceived: 200 }
   assert.equal(computeRate(next as any, prev as any, 'bytesReceived'), null)
+})
+
+test('computeRate: null when counter regressed (ICE restart / renegotiation)', () => {
+  const prev = { timestamp: 1000, bytesReceived: 500 }
+  const next = { timestamp: 2000, bytesReceived: 100 }
+  assert.equal(computeRate(next as any, prev as any, 'bytesReceived'), null)
+})
+
+test('computeRate: tolerates BigInt-like counters via Number()', () => {
+  const prev = { timestamp: 1000, bytesReceived: BigInt(100) } as any
+  const next = { timestamp: 2000, bytesReceived: BigInt(600) } as any
+  assert.equal(computeRate(next, prev, 'bytesReceived'), 500)
+})
+
+test('computePacketLossRate: clamps to [0, 1] and returns 0 when no loss', () => {
+  const prev = { timestamp: 1000, packetsReceived: 100, packetsLost: 0 }
+  const next = { timestamp: 2000, packetsReceived: 200, packetsLost: 0 }
+  assert.equal(computePacketLossRate(next as any, prev as any), 0)
+})
+
+test('computePacketLossRate: fraction of dropped packets between samples', () => {
+  const prev = { timestamp: 1000, packetsReceived: 100, packetsLost: 0 }
+  const next = { timestamp: 2000, packetsReceived: 190, packetsLost: 10 }
+  assert.equal(computePacketLossRate(next as any, prev as any), 10 / 100)
+})
+
+test('computePacketLossRate: treats small negative lost delta as zero (late arrivals)', () => {
+  const prev = { timestamp: 1000, packetsReceived: 100, packetsLost: 5 }
+  const next = { timestamp: 2000, packetsReceived: 200, packetsLost: 3 }
+  assert.equal(computePacketLossRate(next as any, prev as any), 0)
+})
+
+test('computePacketLossRate: null with no previous sample', () => {
+  const next = { timestamp: 2000, packetsReceived: 190, packetsLost: 10 }
+  assert.equal(computePacketLossRate(next as any, null as any), null)
 })
 
 test('map2obj: Map to plain object', () => {
@@ -84,4 +119,29 @@ test('parseStats: bitrate on second sample (local + remote)', () => {
 
   const remoteBr = second!.remote!.audio.inbound[0].bitrate
   assert.ok(typeof remoteBr === 'number' && remoteBr > 0, 'remote inbound bitrate')
+})
+
+test('parseStats: inbound rows get packetLossRate in [0, 1] on second sample', () => {
+  const base = {
+    id: 'in1',
+    type: 'inbound-rtp',
+    kind: 'video',
+    bytesReceived: 1000,
+    packetsReceived: 100,
+    packetsLost: 0
+  }
+  const first = parseStats(
+    mockStatsMap({ in1: { ...base, timestamp: 1000 } }),
+    null
+  )
+  const second = parseStats(
+    mockStatsMap({
+      in1: { ...base, timestamp: 2000, bytesReceived: 5000, packetsReceived: 190, packetsLost: 10 }
+    }),
+    first
+  )
+  const row = second!.video.inbound[0]
+  assert.ok(row.packetLossRate != null, 'packetLossRate is computed')
+  assert.ok(row.packetLossRate! >= 0 && row.packetLossRate! <= 1, 'packetLossRate is within [0, 1]')
+  assert.equal(row.packetLossRate, 10 / 100)
 })

--- a/test/getDisplayMedia-wrap.test.ts
+++ b/test/getDisplayMedia-wrap.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Mirrors the getUserMedia wrap tests for getDisplayMedia (screen share).
+ * Same invariants: single wrap per page, native invoked once, destroy order irrelevant,
+ * restore native only when the last subscriber is destroyed, and an external wrapper
+ * installed on top of ours is preserved on destroy.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+type GDM = (constraints?: any) => Promise<MediaStream>
+
+function installBrowserMocks () {
+  const g = globalThis as Record<string, unknown>
+  const priorWindow = g.window
+  const priorNavigator = g.navigator
+
+  const mediaDevices: { getDisplayMedia: GDM, getUserMedia?: any } = {
+    getDisplayMedia: null as unknown as GDM
+  }
+
+  let nativeInvocations = 0
+  const nativeImpl: GDM = function (this: unknown, _constraints?: any) {
+    nativeInvocations++
+    return Promise.resolve({ getTracks: () => [] } as MediaStream)
+  }
+  mediaDevices.getDisplayMedia = nativeImpl.bind(mediaDevices) as GDM
+  const initialGetDisplayMedia = mediaDevices.getDisplayMedia
+
+  g.window = g
+  g.navigator = { mediaDevices }
+
+  return {
+    mediaDevices,
+    initialGetDisplayMedia,
+    get nativeInvocations () { return nativeInvocations },
+    resetCounter () { nativeInvocations = 0 },
+    restore () {
+      if (priorWindow !== undefined) g.window = priorWindow
+      else delete g.window
+      if (priorNavigator !== undefined) g.navigator = priorNavigator
+      else delete g.navigator
+    }
+  }
+}
+
+async function loadWebRTCStats () {
+  // Cache-bust so module-level state resets per test.
+  const mod = await import('../src/index.ts?t=' + Math.random())
+  return mod.WebRTCStats
+}
+
+test('getDisplayMedia: two instances share a single wrap', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+    const wrapperAfterFirst = (globalThis.navigator.mediaDevices as any).getDisplayMedia
+    const s2 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+
+    assert.strictEqual(
+      (globalThis.navigator.mediaDevices as any).getDisplayMedia,
+      wrapperAfterFirst,
+      'second instance must NOT replace the wrapper (single wrap)'
+    )
+
+    await (globalThis.navigator.mediaDevices as any).getDisplayMedia({ video: true })
+    assert.equal(env.nativeInvocations, 1, 'native getDisplayMedia invoked once per call')
+
+    s1.destroy()
+    s2.destroy()
+    assert.strictEqual(
+      (globalThis.navigator.mediaDevices as any).getDisplayMedia,
+      env.initialGetDisplayMedia,
+      'native restored after all instances destroyed'
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('getDisplayMedia: all subscribed instances receive timeline events', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+    const s2 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+
+    let s1Events = 0
+    let s2Events = 0
+    s1.on('timeline', (ev: any) => { if (ev.tag === 'getDisplayMedia') s1Events++ })
+    s2.on('timeline', (ev: any) => { if (ev.tag === 'getDisplayMedia') s2Events++ })
+
+    await (globalThis.navigator.mediaDevices as any).getDisplayMedia({ video: true })
+
+    assert.equal(s1Events, 2, 'first instance observes request + stream')
+    assert.equal(s2Events, 2, 'second instance observes request + stream')
+    assert.equal(env.nativeInvocations, 1)
+
+    s1.destroy()
+    s2.destroy()
+  } finally {
+    env.restore()
+  }
+})
+
+test('getDisplayMedia: destroy order does not matter (no LIFO requirement)', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+    const s2 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+
+    s1.destroy()
+    env.resetCounter()
+    await (globalThis.navigator.mediaDevices as any).getDisplayMedia({ video: true })
+    assert.equal(env.nativeInvocations, 1)
+
+    s2.destroy()
+    assert.strictEqual(
+      (globalThis.navigator.mediaDevices as any).getDisplayMedia,
+      env.initialGetDisplayMedia
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('getDisplayMedia: error path fans out and propagates rejection', async () => {
+  const env = installBrowserMocks()
+  try {
+    // Replace native with a rejecting impl.
+    const err = new Error('denied')
+    ;(globalThis.navigator.mediaDevices as any).getDisplayMedia = function () {
+      return Promise.reject(err)
+    }
+
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetDisplayMedia: true, getStatsInterval: 60_000 })
+    let errorEvents = 0
+    s1.on('timeline', (ev: any) => {
+      if (ev.tag === 'getDisplayMedia' && ev.data && ev.data.error) errorEvents++
+    })
+
+    await assert.rejects(
+      (globalThis.navigator.mediaDevices as any).getDisplayMedia({ video: true }),
+      /denied/
+    )
+    assert.equal(errorEvents, 1, 'error subscriber fires exactly once')
+
+    s1.destroy()
+  } finally {
+    env.restore()
+  }
+})

--- a/test/getUserMedia-wrap.test.ts
+++ b/test/getUserMedia-wrap.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Validates getUserMedia wrapping when multiple WebRTCStats instances exist (SPA / re-init).
+ *
+ * Regression: a module-level "original" ref was overwritten on each init, which caused
+ * infinite recursion (RangeError: Maximum call stack size exceeded) once more than one
+ * WebRTCStats wrapped gUM on the same page.
+ *
+ * New contract (single-wrap + subscriber registry):
+ *   - gUM is wrapped at most once per page, no matter how many WebRTCStats instances exist.
+ *   - Each instance subscribes to receive timeline events for every gUM call.
+ *   - Native gUM is invoked exactly once per call.
+ *   - Only when the LAST subscribing instance is destroyed is native gUM restored.
+ *   - Destroy order does not matter (no LIFO requirement).
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+type GUM = typeof navigator.mediaDevices.getUserMedia
+
+function installBrowserMocks () {
+  const g = globalThis as Record<string, unknown>
+  const priorWindow = g.window
+  const priorNavigator = g.navigator
+
+  const mediaDevices: { getUserMedia: GUM } = { getUserMedia: null as unknown as GUM }
+
+  let nativeInvocations = 0
+  const nativeImpl: GUM = function (this: unknown, _constraints: MediaStreamConstraints) {
+    nativeInvocations++
+    return Promise.resolve({
+      getTracks: () => []
+    } as MediaStream)
+  }
+  mediaDevices.getUserMedia = nativeImpl.bind(mediaDevices) as GUM
+  const initialGetUserMedia = mediaDevices.getUserMedia
+
+  g.window = g
+  g.navigator = { mediaDevices }
+
+  return {
+    mediaDevices,
+    initialGetUserMedia,
+    get nativeInvocations () {
+      return nativeInvocations
+    },
+    resetCounter () {
+      nativeInvocations = 0
+    },
+    restore () {
+      if (priorWindow !== undefined) g.window = priorWindow
+      else delete g.window
+      if (priorNavigator !== undefined) g.navigator = priorNavigator
+      else delete g.navigator
+    }
+  }
+}
+
+async function loadWebRTCStats () {
+  // Import with a cache-busting query so each test gets its own module-level state
+  // (installed wrapper / previous / subscribers are module-scoped by design).
+  const mod = await import('../src/index.ts?t=' + Math.random())
+  return mod.WebRTCStats
+}
+
+test('getUserMedia: two instances share a single wrap (no recursion, native called once)', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+    const wrapperAfterFirst = globalThis.navigator.mediaDevices.getUserMedia
+    const s2 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+
+    assert.strictEqual(
+      globalThis.navigator.mediaDevices.getUserMedia,
+      wrapperAfterFirst,
+      'second instance must NOT replace the wrapper (single wrap)'
+    )
+
+    await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })
+    assert.equal(env.nativeInvocations, 1, 'native getUserMedia is invoked once per call')
+
+    s1.destroy()
+    s2.destroy()
+    assert.strictEqual(
+      globalThis.navigator.mediaDevices.getUserMedia,
+      env.initialGetUserMedia,
+      'after all subscribers destroyed, native is restored'
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('getUserMedia: wrapper stays installed until the LAST subscriber is destroyed', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+    const s2 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+    const s3 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+
+    const wrapperRef = globalThis.navigator.mediaDevices.getUserMedia
+
+    s2.destroy()
+    assert.strictEqual(globalThis.navigator.mediaDevices.getUserMedia, wrapperRef)
+    s1.destroy()
+    assert.strictEqual(globalThis.navigator.mediaDevices.getUserMedia, wrapperRef)
+
+    env.resetCounter()
+    await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })
+    assert.equal(env.nativeInvocations, 1, 'wrapper remains functional while any subscriber is alive')
+
+    s3.destroy()
+    assert.strictEqual(
+      globalThis.navigator.mediaDevices.getUserMedia,
+      env.initialGetUserMedia,
+      'destroying the last subscriber restores native gUM'
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('getUserMedia: destroy order does not matter (no LIFO requirement)', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+    const s2 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+
+    s1.destroy()
+    env.resetCounter()
+    await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })
+    assert.equal(env.nativeInvocations, 1, 'still works after first instance destroyed')
+
+    s2.destroy()
+    assert.strictEqual(
+      globalThis.navigator.mediaDevices.getUserMedia,
+      env.initialGetUserMedia,
+      'native restored after last instance destroyed'
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('getUserMedia: subscriber callbacks fire for every instance on a single gUM call', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+    const s2 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+
+    let s1Events = 0
+    let s2Events = 0
+    s1.on('timeline', (ev: any) => { if (ev.tag === 'getUserMedia') s1Events++ })
+    s2.on('timeline', (ev: any) => { if (ev.tag === 'getUserMedia') s2Events++ })
+
+    await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })
+
+    // One "constraints" event + one "stream" event per instance
+    assert.equal(s1Events, 2, 'first instance observes request + stream')
+    assert.equal(s2Events, 2, 'second instance observes request + stream')
+    assert.equal(env.nativeInvocations, 1, 'native gUM still invoked exactly once')
+
+    s1.destroy()
+    s2.destroy()
+  } finally {
+    env.restore()
+  }
+})
+
+test('getUserMedia: creating N instances does not deepen the wrap', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const instances = Array.from({ length: 5 }, () => new WebRTCStats({
+      wrapGetUserMedia: true,
+      getStatsInterval: 60_000
+    }))
+
+    env.resetCounter()
+    await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })
+    assert.equal(env.nativeInvocations, 1, 'native called once regardless of instance count')
+
+    instances.forEach((s) => s.destroy())
+    assert.strictEqual(
+      globalThis.navigator.mediaDevices.getUserMedia,
+      env.initialGetUserMedia,
+      'native restored after all instances destroyed'
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('getUserMedia: external wrapper installed AFTER us is preserved on destroy', async () => {
+  const env = installBrowserMocks()
+  try {
+    const WebRTCStats = await loadWebRTCStats()
+    const s1 = new WebRTCStats({ wrapGetUserMedia: true, getStatsInterval: 60_000 })
+
+    const ourWrapper = globalThis.navigator.mediaDevices.getUserMedia
+    let thirdPartyInvocations = 0
+    const thirdPartyWrapper: GUM = function (this: unknown, constraints: MediaStreamConstraints) {
+      thirdPartyInvocations++
+      return ourWrapper.call(globalThis.navigator.mediaDevices, constraints)
+    }
+    globalThis.navigator.mediaDevices.getUserMedia = thirdPartyWrapper.bind(globalThis.navigator.mediaDevices) as GUM
+    const afterExternal = globalThis.navigator.mediaDevices.getUserMedia
+
+    s1.destroy()
+    assert.strictEqual(
+      globalThis.navigator.mediaDevices.getUserMedia,
+      afterExternal,
+      'must not remove a wrapper installed on top of ours'
+    )
+
+    env.resetCounter()
+    await globalThis.navigator.mediaDevices.getUserMedia({ audio: true })
+    assert.equal(thirdPartyInvocations, 1, 'third-party wrapper still runs')
+    assert.equal(env.nativeInvocations, 1, 'native still runs through pass-through')
+  } finally {
+    env.restore()
+  }
+})


### PR DESCRIPTION
## Summary
Bumps to **5.9.0** on top of 5.8.0 (already on master via #21). Additive features + bug fixes, no breaking API changes.
### Bug fixes
- **`getUserMedia` wrap recursion** — root cause of the "Maximum call stack exceeded" reports in production for customers who run multiple sessions per day. Replaced the old per-instance wrap-and-remember-previous with a single module-level wrapper + subscriber registry: the wrapper is installed at most once per page, every `WebRTCStats` instance just subscribes, and native is restored only when the last subscriber goes away. Order of `destroy()` calls no longer matters.
- **`computeRate`** returns `null` on counter regression (ICE restart, stats reset) and tolerates `BigInt` counters via `Number()` coercion instead of returning `NaN`.
- **`packetRate`** was incorrectly multiplied by 8 (bitrate-style scaling on a packet counter). Now uses `computeRate` directly — value is packets/second as documented.
### New features (additive, non-breaking)
- **`wrapGetDisplayMedia`** constructor option with the same single-wrap + subscriber semantics as `wrapGetUserMedia`. Emits `getDisplayMedia` timeline events (`request` / `stream` / `error`). New `'getDisplayMedia'` `TimelineTag` and `GetDisplayMediaResponse` type.
- **`packetLossRate`** on inbound `TrackReport` — fraction in `[0, 1]` derived from `packetsLost` / `packetsReceived` deltas, with negative-delta tolerance (late-arriving packets are spec-allowed) and explicit clamping.
### Tests
- `test/getUserMedia-wrap.test.ts` — two instances share one wrap (no recursion, native invoked once), subscribers fan out, destroy order doesn't matter, external wrappers installed after us are preserved on destroy.
- `test/getDisplayMedia-wrap.test.ts` — mirrors the gUM suite + an error-path test.
- `test/basic.test.ts` — BigInt counters, regression deltas, `packetLossRate` clamping, end-to-end `parseStats` assertion.
### Demo (`example/index.html`)
- **New session (no refresh)** button — tears down and recreates `WebRTCStats` to exercise the wrap invariants without a page reload.
- **Share screen (peer 1 → peer 2)** button — calls `getDisplayMedia` and `replaceTrack`s the screen onto pc1's video sender so peer 2 actually receives it. Hint text explains the one-way asymmetry so the charts aren't confusing.
- **Send bitrate** chart (outbound audio + video) alongside the existing Receive bitrate chart.
### Chore
- `author` in `package.json` updated to Alberto Gonzalez / WebRTC.ventures; Andrei Onel moved to `contributors` so prior work stays credited on the npm page.
- `LICENSE` appends a `Copyright (c) 2025-present Alberto Gonzalez <alberto@webrtc.ventures> (WebRTC.ventures)` line; the original 2019 Andrei Onel line is preserved.
## Test plan
- [x] `npm test` — 3 files, all pass
- [x] `npm run build` — clean
- [x] Open `example/index.html`, click Start → Connect → Share screen. Confirm peer 2's remote preview switches to the screen, Send bitrate on peer 1 shifts, peer 1's Receive bitrate stays flat (still camera from peer 2).
- [x] Stop share → camera restored, both bitrate charts return to pre-share levels.
- [x] New session (no refresh) → no console errors; repeat Start/Connect works.
- [x] After merge: tag `v5.9.0` and `npm publish` from `master`.